### PR TITLE
1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@citizensadvice/rails-form-inputs",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@citizensadvice/rails-form-inputs",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "ISC",
       "devDependencies": {
         "@citizensadvice/form-to-rack-params": "v1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/rails-form-inputs",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "React component to turn an object into Rails compatible form inputs",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Remove `defautProps` for React 18.3 compatibility and replace with destructuring defaults.